### PR TITLE
Fix: 닉네임 등록 에러 해결

### DIFF
--- a/src/containers/profile/SetNicknameContainer.jsx
+++ b/src/containers/profile/SetNicknameContainer.jsx
@@ -1,20 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import SetNickname from '../../components/profile/SetNickname';
-import {
-  checkNickname,
-  initAuth,
-  nicknameChanged,
-  setNickname,
-} from '../../modules/auth';
-import { check, setNicknameState } from '../../modules/user';
+import { checkNickname, nicknameChanged, setNickname } from '../../modules/auth';
+import { check } from '../../modules/user';
 
 const SetNicknameContainer = (props) => {
-  const { user } = useSelector((state) => state.user);
-  const { nicknameChecked, setNicknameSuccess } = useSelector(
-    (state) => state.auth,
-  );
+  const { nicknameChecked } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -26,39 +18,11 @@ const SetNicknameContainer = (props) => {
     dispatch(nicknameChanged());
   };
 
-  const onSetNickname = ({ nickname }) => {
-    dispatch(setNickname({ nickname }));
+  const onSetNickname = async ({ nickname }) => {
+    await dispatch(setNickname({ nickname }));
+    await dispatch(check());
+    history.push('/');
   };
-
-  useEffect(() => {
-    return () => {
-      dispatch(initAuth());
-    };
-  }, [dispatch]);
-
-  useEffect(() => {
-    if (!!setNicknameSuccess) {
-      dispatch(setNicknameState({ nickname: setNicknameSuccess }));
-      dispatch(check());
-      history.push('/');
-    }
-  }, [setNicknameSuccess, history, dispatch]);
-
-  useEffect(() => {
-    if (user) {
-      if (user.isAdmin) {
-        alert('관리자님 환영합니다!');
-        history.push('/admin');
-      } else {
-        if (!user.nickname) {
-          alert('닉네임을 등록해주세요.');
-        } else {
-          alert(`${user.nickname}님 안녕하세요!`);
-          history.push('/');
-        }
-      }
-    }
-  }, [user, history]);
 
   return (
     <SetNickname

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -45,7 +45,6 @@ const initialState = {
   codeSent: null,
   codeVerified: null,
   nicknameChecked: null,
-  setNicknameSuccess: null,
   error: null,
 };
 
@@ -66,10 +65,6 @@ export default handleActions(
     [INIT_AUTH]: () => initialState,
     ...pender({
       type: SET_NICKNAME,
-      onSuccess: (state, { meta: { nickname } }) => ({
-        ...state,
-        setNicknameSuccess: nickname,
-      }),
     }),
     ...pender({
       type: CHECK_NICKNAME,

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -5,7 +5,6 @@ import * as profileAPI from '../lib/api/profile';
 
 const UNFOLLOW = 'user/UNFOLLOW';
 const FOLLOW = 'user/FOLLOW';
-const SET_NICKNAME_STATE = 'user/SET_NICKNAME_STATE';
 const CHECK = 'user/CHECK';
 const LOGOUT = 'user/LOGOUT';
 const INITIAL_USER = 'user/INITIAL_USER';
@@ -14,7 +13,6 @@ export const unfollow = createAction(UNFOLLOW, profileAPI.unfollow);
 export const follow = createAction(FOLLOW, profileAPI.follow);
 export const check = createAction(CHECK, authAPI.check);
 export const logout = createAction(LOGOUT, authAPI.logout);
-export const setNicknameState = createAction(SET_NICKNAME_STATE);
 export const initialUser = createAction(INITIAL_USER);
 
 const initialState = {
@@ -26,10 +24,6 @@ const initialState = {
 
 export default handleActions(
   {
-    [SET_NICKNAME_STATE]: (state, { payload: { nickname } }) => ({
-      ...state,
-      user: { ...state.user, nickname },
-    }),
     [INITIAL_USER]: (state) => initialState,
     [CHECK]: (state) => ({
       ...state,


### PR DESCRIPTION
## 버그 내용
- 닉네임 등록 후 전역 상태에 있는 유저 정보에 닉네임이 업데이트 되지 않은 상태로 메인으로 넘어갔기 때문에 메인에서 바로 닉네임 등록 페이지로 다시 넘어오게 된 것 같습니다.
- 따라서 닉네임 등록 과 유저정보 확인 액션을 await 해준 뒤 history.push해주면 됩니다.

## 작업내용
- 닉네임 등록 후 유저정보 확인 후 페이지 이동
- 닉네임 등록 로직 단순화