### PR TITLE
Feat: 채널 모아보기 페이지, 개별 아카이브 조회 페이지 구현

### DIFF
--- a/src/components/archive/Archive.jsx
+++ b/src/components/archive/Archive.jsx
@@ -1,0 +1,209 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import {
+  Box,
+  Typography,
+  Avatar,
+  ClickAwayListener,
+  Popper,
+  Paper,
+  MenuList,
+  MenuItem,
+  ListItemText,
+  Divider,
+} from '@material-ui/core';
+import { useState } from 'react';
+import { ReactComponent as PostSetting } from '../../lib/assets/postSetting.svg';
+import { getDateString } from '../../lib/util/dateFormat';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import { Viewer } from '@toast-ui/react-editor';
+import editorConfig from '../../lib/util/editorConfig';
+import ArchiveStatusIcon from './ArchiveStatusIcon';
+
+const Archive = ({ userId, channel, archive }) => {
+  const [menuAnchor, setMenuAnchor] = useState();
+  const handleMenuClick = (e) => {
+    if (!e) return;
+    setMenuAnchor(menuAnchor ? null : e.currentTarget);
+  };
+
+  const PostMenu = () => (
+    <Popper open={!!menuAnchor} anchorEl={menuAnchor} placement="bottom">
+      <ClickAwayListener
+        onClickAway={() => {
+          setMenuAnchor(null);
+        }}
+      >
+        <Paper>
+          <MenuList dense css={menuWrapper}>
+            <MenuItem>
+              <ListItemText>신고하기</ListItemText>
+            </MenuItem>
+            <Divider />
+            <MenuItem>
+              <ListItemText>수정하기</ListItemText>
+            </MenuItem>
+            <Divider />
+            {userId === archive.ownerId && (
+              <MenuItem>
+                <ListItemText>삭제하기</ListItemText>
+              </MenuItem>
+            )}
+          </MenuList>
+        </Paper>
+      </ClickAwayListener>
+    </Popper>
+  );
+
+  return (
+    <Box css={backgroundWrapper}>
+      <Box css={archiveWrapper}>
+        <Box css={archiveTitleWrapper}>
+          {archive.postId && <ArchiveStatusIcon />}
+          <Typography className="title">{archive.title}</Typography>
+          <Box css={ownerWrapper}>
+            <Avatar
+              src={archive.owner.profile.profileImage}
+              css={ownerIcon(archive.ownerId === channel.adminId)}
+            />
+            <Typography className="nickname">{archive.owner.nickname}</Typography>
+            <Typography className="date">{getDateString(archive.createdAt)}</Typography>
+            <PostSetting css={menuButton} onClick={handleMenuClick} />
+            <PostMenu />
+          </Box>
+        </Box>
+      </Box>
+      <Box css={archiveContentWrapper}>
+        <Box css={editorConfig.editorCss}>
+          <Viewer
+            viewer={true}
+            initialValue={archive.content}
+            customHTMLRenderer={editorConfig.renderer}
+          />
+        </Box>
+        <Box css={tagsCss}>
+          {archive.tags.map((tag) => (
+            <Typography key={tag.id} css={tagCss}>
+              {tag.tag.name}
+            </Typography>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const backgroundWrapper = css`
+  margin-top: 8.4375rem;
+  background: #fafafc;
+  padding: 0 calc((100% - 71.25rem) / 2);
+`;
+
+const archiveWrapper = css`
+  margin-top: 5rem;
+  height: fit-content;
+  border-bottom: 1px solid #bdbdbd;
+`;
+
+const archiveTitleWrapper = css`
+  display: flex;
+  flex-direction: column;
+  padding: 1.875rem 1.875rem 1.25rem 1.875rem;
+  & .MuiTypography-root {
+    font-family: 'Barlow', 'Noto Sans KR';
+  }
+  .title {
+    margin-top: 0.9375rem;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 2.125rem;
+    color: #000000;
+  }
+  .nickname {
+    margin-left: 0.5rem;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 0.9375rem;
+    color: #000000;
+  }
+  .date {
+    font-family: 'Noto Sans KR';
+    margin-left: 1.875rem;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 0.9375rem;
+  }
+`;
+
+const archiveContentWrapper = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 1.875rem;
+`;
+
+const ownerWrapper = css`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 1.875rem;
+  height: 3.4375rem;
+`;
+
+const ownerIcon = (isAdmin) => css`
+  width: 2.1875rem;
+  height: 2.1875rem;
+  border: ${isAdmin && '2px solid #04BD9E'};
+`;
+
+const menuButton = css`
+  cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  justify-content: center;
+  margin-left: 1.25rem;
+`;
+
+const menuWrapper = css`
+  width: 8.34rem;
+  max-height: 11.25rem;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
+  z-index: 1001;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  .MuiListItem-root {
+    padding: 0;
+    flex: 1;
+    min-height: 3.4375rem;
+    .MuiTypography-root {
+      font-family: 'Noto Sans KR';
+      font-size: 1.167rem;
+      text-align: center;
+    }
+    &:hover {
+      .MuiTypography-root {
+        font-weight: bold;
+      }
+    }
+  }
+`;
+
+const tagsCss = css`
+  display: flex;
+  row-gap: 0.625rem;
+  column-gap: 1.75rem;
+  flex-wrap: wrap;
+  margin-top: 12.5rem;
+`;
+
+const tagCss = css`
+  font-size: 1.125rem;
+  color: #7b7b7b;
+  ::before {
+    content: '#';
+  }
+`;
+
+export default Archive;

--- a/src/components/archive/Archive.jsx
+++ b/src/components/archive/Archive.jsx
@@ -39,15 +39,17 @@ const Archive = ({ userId, channel, archive }) => {
             <MenuItem>
               <ListItemText>신고하기</ListItemText>
             </MenuItem>
-            <Divider />
-            <MenuItem>
-              <ListItemText>수정하기</ListItemText>
-            </MenuItem>
-            <Divider />
             {userId === archive.ownerId && (
-              <MenuItem>
-                <ListItemText>삭제하기</ListItemText>
-              </MenuItem>
+              <>
+                <Divider />
+                <MenuItem>
+                  <ListItemText>수정하기</ListItemText>
+                </MenuItem>
+                <Divider />
+                <MenuItem>
+                  <ListItemText>삭제하기</ListItemText>
+                </MenuItem>
+              </>
             )}
           </MenuList>
         </Paper>

--- a/src/components/archive/ArchiveButtonList.jsx
+++ b/src/components/archive/ArchiveButtonList.jsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { ReactComponent as LikeIcon } from '../../lib/assets/likeIcon.svg';
+import { ReactComponent as LikedButton } from '../../lib/assets/likedButton.svg';
+import { ReactComponent as PostGo } from '../../lib/assets/postGo.svg';
+import { Box, Button } from '@material-ui/core';
+import palette from '../../lib/styles/palette';
+
+const ArchiveButtonList = ({ archive, isLiked, onLikeArchive, onUnlikeArchive }) => {
+  return (
+    <Box css={wrapper}>
+      <Box css={{ marginRight: '1.875rem' }}>
+        <Button
+          css={likeButton(isLiked)}
+          onClick={() => {
+            isLiked ? onUnlikeArchive() : onLikeArchive();
+          }}
+        >
+          {isLiked ? <LikedButton className="icon" /> : <LikeIcon className="icon" />}
+          공감
+        </Button>
+
+        {archive.postId && (
+          <Button css={goPostButton}>
+            <PostGo className="icon" />
+            요청글 바로 가기
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const wrapper = css`
+  padding: 0 calc((100% - 71.25rem) / 2);
+  background: #fafafc;
+  display: flex;
+  justify-content: flex-end;
+
+  & .MuiButton-root {
+    font-family: 'Barlow', 'Noto Sans KR';
+    font-style: normal;
+    font-weight: bold;
+    font-size: 1.125rem;
+    height: 3.125rem;
+    margin-left: 1.25rem;
+  }
+`;
+
+const likeButton = (isLiked) => css`
+  width: 6.5625rem;
+  color: ${isLiked ? palette.orange : palette.black};
+  background: ${palette.white};
+  border: 2px solid ${isLiked ? palette.orange : palette.black};
+  border-radius: 3.125rem;
+  .icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.625rem;
+  }
+`;
+
+const goPostButton = css`
+  width: 12.1875rem;
+  color: white;
+  background: #252424;
+  border-radius: 100px;
+  &:hover {
+    background-color: #252424cc;
+  }
+  .icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.625rem;
+  }
+`;
+
+export default ArchiveButtonList;

--- a/src/components/archive/ArchiveList.jsx
+++ b/src/components/archive/ArchiveList.jsx
@@ -5,7 +5,6 @@ import Button from '../common/Button';
 import { ReactComponent as PostWrite } from '../../lib/assets/postWrite.svg';
 import { getDateString } from '../../lib/util/dateFormat';
 import { useHistory } from 'react-router';
-import { Image } from '@material-ui/icons';
 
 const Item = ({ channel, archive }) => {
   const history = useHistory();
@@ -51,7 +50,7 @@ const Item = ({ channel, archive }) => {
       </Box>
       {archive.images.length !== 0 && (
         <Box css={itemRight}>
-          <img src={archive.images[0]} alt={archive.images[0]} />
+          <img src={archive.images[0].src} alt={archive.images[0].src} />
         </Box>
       )}
     </Box>

--- a/src/components/archive/ArchiveList.jsx
+++ b/src/components/archive/ArchiveList.jsx
@@ -7,62 +7,58 @@ import { getDateString } from '../../lib/util/dateFormat';
 import { useHistory } from 'react-router';
 import { Image } from '@material-ui/icons';
 
-const ArchiveItem = ({ channel, archive }) => {
+const Item = ({ channel, archive }) => {
   const history = useHistory();
 
   return (
     <Box
-      css={postItem}
+      css={item}
       onClick={() => {
         history.push(`/channel/${channel.id}/archive/${archive.id}`);
       }}
     >
-      <Box css={postItemLeft}>
-        <Box css={postTitle}>
+      <Box css={itemLeft}>
+        <Box css={title}>
           <Box css={{ display: 'flex' }}>
             <Typography className="title">{archive.title}</Typography>
           </Box>
           <Typography className="date">{getDateString(archive.createdAt)}</Typography>
         </Box>
-        <Typography css={postContent}>{archive.content}</Typography>
+        <Typography css={content}>{archive.content}</Typography>
         <Box css={{ display: 'flex', alignItems: 'center' }}>
           {archive.authorId === channel.adminId ? (
             <>
-              <div css={adminIconCss}>
+              <div css={adminIcon}>
                 <p>관리자</p>
               </div>
               <Avatar
                 src={archive.owner.profile.profileImage}
                 css={{
-                  width: '3.125rem',
-                  height: '3.125rem',
+                  width: '2.8125rem',
+                  height: '2.8125rem',
                   border: '2px solid #04BD9E',
                 }}
               />
             </>
           ) : (
-            <>
-              <Avatar
-                src={archive.owner.profile.profileImage}
-                css={{ width: '3.125rem', height: '3.125rem' }}
-              />
-            </>
+            <Avatar
+              src={archive.owner.profile.profileImage}
+              css={{ width: '2.8125rem', height: '2.8125rem' }}
+            />
           )}
-          <Typography css={nicknameCss}>{archive.owner.nickname}</Typography>
+          <Typography css={nickname}>{archive.owner.nickname}</Typography>
         </Box>
       </Box>
-      <Box
-        css={postItemRight}
-        className="avatar"
-        onClick={() => history.push(`/profile/${archive.owner.id}`)}
-      >
-        {archive.images.length > 0 && <Image src={archive.images[0]} alt="" />}
-      </Box>
+      {archive.images.length !== 0 && (
+        <Box css={itemRight}>
+          <img src={archive.images[0]} alt={archive.images[0]} />
+        </Box>
+      )}
     </Box>
   );
 };
 
-const ChannelArchiveList = ({ channelArchive, channel }) => {
+const ArchiveList = ({ channel, archives }) => {
   const history = useHistory();
 
   return (
@@ -70,21 +66,21 @@ const ChannelArchiveList = ({ channelArchive, channel }) => {
       <Box css={writeTitleWrapper}>
         <Button css={write} onClick={() => history.push(`/channel/${channel.id}/editArchive`)}>
           <PostWrite className="icon" css={{ marginRight: '.625rem' }} />
-          요청하기
+          글쓰기
         </Button>
         <Typography css={writeTitle}>
-          재능과 관련하여 배우고 싶은 내용을 요청해보세요. 재능 고수들이 공유 채팅을 열어 재능
-          업글을 도와줄거예요!
+          채널과 관련하여 공유하고 싶은 내용을 작성해주세요. 자신이 오픈한 채팅 목록을 불러와
+          아카이빙 할 수도 있습니다.
         </Typography>
       </Box>
-      {channelArchive?.length > 0 ? (
-        <Box css={channelArchiveWrapper}>
-          {channelArchive.map((archive) => (
-            <ArchiveItem key={archive.id} channel={channel} archive={archive} />
+      {archives?.length > 0 ? (
+        <Box css={archivesWrapper}>
+          {archives.map((archive) => (
+            <Item key={archive.id} channel={channel} archive={archive} />
           ))}
         </Box>
       ) : (
-        <Typography>아직 등록된 요청글이 없습니다.</Typography>
+        <Typography css={noContents}>아직 등록된 아카이브가 없습니다.</Typography>
       )}
     </Box>
   );
@@ -99,7 +95,7 @@ const backgroudWrapper = css`
 const writeTitleWrapper = css`
   display: flex;
   flex-direction: column;
-  margin: 5rem 1rem;
+  padding: 6.25rem 0;
 `;
 
 const write = css`
@@ -123,7 +119,7 @@ const writeTitle = css`
   margin: 1.875rem auto auto auto;
 `;
 
-const channelArchiveWrapper = css`
+const archivesWrapper = css`
   display: flex;
   flex-direction: column;
   border-top: 2px solid black;
@@ -131,11 +127,11 @@ const channelArchiveWrapper = css`
   margin-bottom: 6.25rem;
 `;
 
-const postItem = css`
-  height: 15rem;
+const item = css`
+  height: 14.875rem;
   border-bottom: 1px solid #bdbdbd;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   cursor: pointer;
   & .MuiTypography-root {
     font-family: 'Barlow', 'Noto Sans KR';
@@ -145,29 +141,31 @@ const postItem = css`
   }
 `;
 
-const postItemLeft = css`
-  flex: 1;
+const itemLeft = css`
   height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   padding: 1.875rem 1.25rem;
 `;
 
-const postItemRight = css`
+const itemRight = css`
+  padding: 1.875rem;
   display: flex;
-  flex-direction: column;
   justify-content: center;
-  width: 11.25rem;
-  height: 10.625rem;
-  padding: 0;
-  margin: 0;
+  align-items: center;
+  img {
+    width: 11.25rem;
+    height: 11.25rem;
+    object-fit: cover;
+  }
 `;
 
-const postTitle = css`
+const title = css`
   width: 100%;
   height: 1.5625rem;
-  margin-bottom: 0.625rem;
+  margin-bottom: 2.5rem;
   display: flex;
   justify-content: space-between;
   & .MuiTypography-root {
@@ -187,9 +185,8 @@ const postTitle = css`
   }
 `;
 
-const postContent = css`
+const content = css`
   flex: 1;
-  margin-top: 2.34375rem;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -202,7 +199,7 @@ const postContent = css`
   color: #5f5f5f;
 `;
 
-const adminIconCss = css`
+const adminIcon = css`
   width: 2.375rem;
   height: 1.125rem;
   background: #04bd9e;
@@ -220,11 +217,20 @@ const adminIconCss = css`
   }
 `;
 
-const nicknameCss = css`
+const nickname = css`
   margin-left: 0.75rem;
   font-family: 'Noto Sans KR';
   font-size: 0.8125rem;
   color: #000000;
 `;
 
-export default ChannelArchiveList;
+const noContents = css`
+  font-family: 'Noto Sans KR', 'sans-serif' !important;
+  font-size: 1rem;
+  color: #5f5f5f;
+  text-align: center;
+  height: 10rem;
+  line-height: 10rem;
+`;
+
+export default ArchiveList;

--- a/src/components/archive/ArchiveStatusIcon.jsx
+++ b/src/components/archive/ArchiveStatusIcon.jsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { Box, Typography } from '@material-ui/core';
+
+const ArchiveStatusIcon = () => {
+  return (
+    <Box css={[defaultStyle, { backgroundColor: 'black' }]}>
+      <Typography>요청 해결</Typography>
+    </Box>
+  );
+};
+
+export default ArchiveStatusIcon;
+
+const defaultStyle = css`
+  width: 5rem;
+  height: 2.125rem;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  .MuiTypography-root {
+    padding: 0;
+    text-align: center;
+    font-family: 'Barlow', 'Noto Sans KR';
+    font-weight: bold;
+    font-size: 0.9375rem;
+    color: #ffffff;
+  }
+`;

--- a/src/containers/archive/ArchiveButtonListContainer.jsx
+++ b/src/containers/archive/ArchiveButtonListContainer.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import Loading from '../../components/common/Loading';
+import ArchiveButtonList from '../../components/archive/ArchiveButtonList';
+import { likeArchive, unlikeArchive } from '../../modules/archive';
+
+const ArchiveButtonListContainer = ({ channelId, archiveId }) => {
+  const { archive, likeError, unlikeError } = useSelector((state) => state.archive);
+  const { user } = useSelector((state) => state.user);
+  const [isLiked, setIsLiked] = useState(false);
+  const dispatch = useDispatch();
+
+  const onLikeArchive = async () => {
+    await dispatch(likeArchive({ channelId, archiveId }));
+    if (!likeError) setIsLiked(true);
+  };
+
+  const onUnlikeArchive = async () => {
+    await dispatch(unlikeArchive({ archiveId }));
+    if (!unlikeError) setIsLiked(false);
+  };
+
+  useEffect(() => {
+    if (archive && user) {
+      setIsLiked(!!archive.archiveLike.filter((like) => like.userId === user.id).length);
+    }
+  }, [archive, user]);
+
+  if (!archive) return <Loading css={{ backgroundColor: '#fafafc' }} />;
+
+  return (
+    <ArchiveButtonList
+      archive={archive}
+      isLiked={isLiked}
+      onLikeArchive={onLikeArchive}
+      onUnlikeArchive={onUnlikeArchive}
+    />
+  );
+};
+
+export default ArchiveButtonListContainer;

--- a/src/containers/archive/ArchiveContainer.jsx
+++ b/src/containers/archive/ArchiveContainer.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { getChannelData } from '../../modules/channel';
+import Loading from '../../components/common/Loading';
+import Archive from '../../components/archive/Archive';
+import { getArchive, initArchive } from '../../modules/archive';
+
+const ArchiveContainer = ({ channelId, archiveId }) => {
+  const {
+    user: { id: userId },
+  } = useSelector((state) => state.user);
+  const { channel } = useSelector((state) => state.channel);
+  const { archive } = useSelector((state) => state.archive);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getChannelData(channelId));
+    dispatch(getArchive(archiveId));
+  }, [dispatch, channelId, archiveId]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(initArchive());
+    };
+  }, [dispatch]);
+
+  if (!channel || !archive) return <Loading css={{ backgroundColor: '#fafafc' }} />;
+
+  return <Archive userId={userId} channel={channel} archive={archive} />;
+};
+
+export default ArchiveContainer;

--- a/src/containers/archive/ArchiveListContainer.jsx
+++ b/src/containers/archive/ArchiveListContainer.jsx
@@ -1,24 +1,26 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
-import ChannelArchiveList from '../../components/channel/ChannelArchiveList';
+import ArchiveList from '../../components/archive/ArchiveList';
 import Loading from '../../components/common/Loading';
-import { getChannelArchive } from '../../modules/archive';
+import { getChannelArchive, initArchive } from '../../modules/archive';
 import { getChannelData } from '../../modules/channel';
 
-const ChannelArchiveListContainer = ({ channelId }) => {
+const ArchiveListContainer = ({ channelId }) => {
   const { channel } = useSelector((state) => state.channel);
   const { channelArchive } = useSelector((state) => state.archive);
   const dispatch = useDispatch();
-  const history = useHistory();
 
   useEffect(() => {
     dispatch(getChannelArchive(channelId));
     dispatch(getChannelData(channelId));
-  }, [dispatch]);
+    return () => {
+      dispatch(initArchive());
+    };
+  }, [dispatch, channelId]);
 
   if (!channel || !channelArchive) return <Loading css={{ backgroundColor: '#fafafc' }} />;
-  return <ChannelArchiveList channelArchive={channelArchive} channel={channel} />;
+
+  return <ArchiveList channel={channel} archives={channelArchive} />;
 };
 
-export default ChannelArchiveListContainer;
+export default ArchiveListContainer;

--- a/src/containers/common/CommentsContainer.jsx
+++ b/src/containers/common/CommentsContainer.jsx
@@ -33,11 +33,11 @@ const CommentsContainer = ({ channelId, postId }) => {
   };
 
   const refreshComments = () => {
-    dispatch(getComments({ postId }));
+    dispatch(getComments(postId));
   };
 
   useEffect(() => {
-    dispatch(getComments({ postId }));
+    dispatch(getComments(postId));
   }, [dispatch]);
 
   useEffect(() => {

--- a/src/lib/api/archive.js
+++ b/src/lib/api/archive.js
@@ -47,7 +47,7 @@ export const likeArchive = async ({ channelId, archiveId }) => {
   return response.data.data;
 };
 
-export const unlikeArchive = async (archiveId) => {
+export const unlikeArchive = async ({ archiveId }) => {
   const response = await axios.post(`/api/Archive/unlike`, { archiveId });
   return response.data.data;
 };

--- a/src/lib/api/archive.js
+++ b/src/lib/api/archive.js
@@ -1,41 +1,53 @@
 import axios from 'axios';
 
-export const getArchive = async (archivedId) => {
-    const response = await axios.get(`/api/Archive/${archivedId}`);
-    return response.data.data;
+export const getArchive = async (archiveId) => {
+  const response = await axios.get(`/api/Archive/${archiveId}`);
+  return response.data.data;
 };
 
 export const getChannelArchive = async (channelId) => {
-    const response = await axios.get(`/api/Archive/channel/${channelId}`);
-    return response.data.data;
+  const response = await axios.get(`/api/Archive/channel/${channelId}`);
+  return response.data.data;
 };
 
 export const getUserArchive = async (userId) => {
-    const response = await axios.get(`/api/Archive/profile/${userId}`);
-    return response.data.data;
+  const response = await axios.get(`/api/Archive/profile/${userId}`);
+  return response.data.data;
 };
 
 export const writeArchive = async ({ channelId, postId, title, status, content, images }) => {
-    const response = await axios.post(`/api/Archive`, { channelId, postId, title, status, content, images });
-    return response.data.data;
+  const response = await axios.post(`/api/Archive`, {
+    channelId,
+    postId,
+    title,
+    status,
+    content,
+    images,
+  });
+  return response.data.data;
 };
 
-export const deleteArchive = async (archivedId) => {
-    const response = await axios.delete(`/api/Archive/${archivedId}`);
-    return response.data.data;
+export const deleteArchive = async (archiveId) => {
+  const response = await axios.delete(`/api/Archive/${archiveId}`);
+  return response.data.data;
 };
 
-export const editArchive = async ({ archivedId, title, status, content, images }) => {
-    const response = await axios.patch(`/api/Archive/${archivedId}`, { title, status, content, images });
-    return response.data.data;
+export const editArchive = async ({ archiveId, title, status, content, images }) => {
+  const response = await axios.patch(`/api/Archive/${archiveId}`, {
+    title,
+    status,
+    content,
+    images,
+  });
+  return response.data.data;
 };
 
-export const likeArchive = async ({ channelId, archivedId }) => {
-    const response = await axios.post(`/api/Archive/like`, { channelId, archivedId });
-    return response.data.data;
+export const likeArchive = async ({ channelId, archiveId }) => {
+  const response = await axios.post(`/api/Archive/like`, { channelId, archiveId });
+  return response.data.data;
 };
 
-export const unlikeArchive = async (archivedId) => {
-    const response = await axios.post(`/api/Archive/unlike`, { archivedId });
-    return response.data.data;
+export const unlikeArchive = async (archiveId) => {
+  const response = await axios.post(`/api/Archive/unlike`, { archiveId });
+  return response.data.data;
 };

--- a/src/lib/assets/postGo.svg
+++ b/src/lib/assets/postGo.svg
@@ -1,0 +1,6 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.4384 26.25H6.5625C6.31386 26.25 6.0754 26.1512 5.89959 25.9754C5.72377 25.7996 5.625 25.5611 5.625 25.3125V4.6875C5.625 4.43886 5.72377 4.2004 5.89959 4.02459C6.0754 3.84877 6.31386 3.75 6.5625 3.75H17.8134L24.3759 10.3125V25.3125C24.3759 25.4356 24.3517 25.5575 24.3046 25.6713C24.2574 25.785 24.1884 25.8884 24.1013 25.9754C24.0143 26.0625 23.9109 26.1315 23.7972 26.1786C23.6834 26.2258 23.5615 26.25 23.4384 26.25Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.8125 3.75V10.3125H24.3759" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.25 15.9375H18.75" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.25 19.6875H18.75" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/util/editorConfig.js
+++ b/src/lib/util/editorConfig.js
@@ -1,23 +1,22 @@
-
 import { uploadImages } from './../api/image';
 import { css } from '@emotion/react';
 
 const renderer = {
   question(node, context) {
     return [
-      { type: 'openTag', tagName: 'div', outerNewLine: true, classNames: ['question'], },
-      { type: 'html', content: node.literal, },
-      { type: 'closeTag', tagName: 'div', outerNewLine: true, },
+      { type: 'openTag', tagName: 'div', outerNewLine: true, classNames: ['question'] },
+      { type: 'html', content: node.literal },
+      { type: 'closeTag', tagName: 'div', outerNewLine: true },
     ];
   },
   answer(node, context) {
     return [
-      { type: 'openTag', tagName: 'div', outerNewLine: true, classNames: ['answer'], },
-      { type: 'html', content: node.literal, },
-      { type: 'closeTag', tagName: 'div', outerNewLine: true, },
+      { type: 'openTag', tagName: 'div', outerNewLine: true, classNames: ['answer'] },
+      { type: 'html', content: node.literal },
+      { type: 'closeTag', tagName: 'div', outerNewLine: true },
     ];
   },
-}
+};
 const hooks = {
   addImageBlobHook: async function (blob, callback) {
     let formData = new FormData();
@@ -28,6 +27,11 @@ const hooks = {
 };
 
 const editorCss = css`
+  .toastui-editor-contents > div {
+    display: flex;
+    flex-direction: column;
+  }
+
   .toastui-editor-contents p {
     font-family: 'Barlow', 'Noto Sans KR';
     font-style: normal;
@@ -36,28 +40,49 @@ const editorCss = css`
     line-height: 30px;
     letter-spacing: 0.2px;
     color: #000000;
+    margin-bottom: 1.25rem;
   }
-  .toastui-editor-contents .question {
-    border: 1px solid #7b7b7b;
-    border-radius: 10px;
-    background-color: #c8ff8a;
-    width: 200px;
-    margin-right: 0;
-    margin-left: auto;
-    font-size: 20px;
-    font-family: 'Barlow', 'Noto Sans KR';
-  }
+
+  .toastui-editor-contents .question,
   .toastui-editor-contents .answer {
-    border: 1px solid #7b7b7b;
-    border-radius: 10px;
-    background-color: #8aecff;
-    width: 200px;
-    font-size: 20px;
+    box-sizing: border-box;
+    min-height: 4.125rem;
+    max-width: 53.125rem;
+    padding: 1.25rem;
+    border-radius: 1.875rem;
+    font-size: 1rem;
+    font-weight: 600;
     font-family: 'Barlow', 'Noto Sans KR';
+    margin-bottom: 1.25rem;
+    &::before {
+      font-size: 1.25rem;
+      font-weight: 700;
+      margin-right: 1.875rem;
+    }
   }
+
+  .toastui-editor-contents .question {
+    color: white;
+    border-top-left-radius: 0;
+    background-color: #474747;
+    &::before {
+      content: 'Q';
+    }
+  }
+
+  .toastui-editor-contents .answer {
+    align-self: flex-end;
+    border-bottom-right-radius: 0;
+    background-color: #f0f0f0;
+    &::before {
+      content: 'A';
+    }
+  }
+
   .toastui-editor-contents::-webkit-scrollbar {
     width: 10px;
   }
+
   .toastui-editor-contents::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 5px;

--- a/src/modules/archive.js
+++ b/src/modules/archive.js
@@ -23,6 +23,8 @@ const initialState = {
   userArchive: null,
   archive: null,
   error: null,
+  likeError: false,
+  unlikeError: false,
 };
 
 export default handleActions(
@@ -47,6 +49,28 @@ export default handleActions(
       onSuccess: (state, { payload: userArchive }) => ({
         ...state,
         userArchive,
+      }),
+    }),
+    ...pender({
+      type: LIKE_ARCHIVE,
+      onSuccess: (state) => ({
+        ...state,
+        likeError: false,
+      }),
+      onFailure: (state) => ({
+        ...state,
+        likeError: true,
+      }),
+    }),
+    ...pender({
+      type: UNLIKE_ARCHIVE,
+      onSuccess: (state) => ({
+        ...state,
+        unlikeError: false,
+      }),
+      onFailure: (state) => ({
+        ...state,
+        unlikeError: true,
       }),
     }),
   },

--- a/src/modules/archive.js
+++ b/src/modules/archive.js
@@ -16,7 +16,7 @@ export const getUserArchive = createAction(GET_USER_ARCHIVE, archiveAPI.getUserA
 export const deleteArchive = createAction(DELETE_ARCHIVE, archiveAPI.deleteArchive);
 export const likeArchive = createAction(LIKE_ARCHIVE, archiveAPI.likeArchive);
 export const unlikeArchive = createAction(UNLIKE_ARCHIVE, archiveAPI.unlikeArchive);
-export const initPost = createAction(INIT_ARCHIVE);
+export const initArchive = createAction(INIT_ARCHIVE);
 
 const initialState = {
   channelArchive: null,

--- a/src/pages/channel/ArchiveListPage.jsx
+++ b/src/pages/channel/ArchiveListPage.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import ChannelArchiveListContainer from '../../containers/channel/ChannelArchiveListContainer';
+import ArchiveListContainer from '../../containers/archive/ArchiveListContainer';
 import ChannelNavContainer from '../../containers/channel/ChannelNavContainer';
 import FooterContainer from '../../containers/common/FooterContainer';
 import HeaderContainer from '../../containers/common/HeaderContainer';
 
-const ChannelArchiveListPage = ({ match }) => {
+const ArchiveListPage = ({ match }) => {
   const { channelId } = match.params;
   return (
     <>
       <HeaderContainer />
       <ChannelNavContainer />
-      <ChannelArchiveListContainer channelId={parseInt(channelId, 10)} />
+      <ArchiveListContainer channelId={parseInt(channelId, 10)} />
       <FooterContainer />
     </>
   );
 };
 
-export default ChannelArchiveListPage;
+export default ArchiveListPage;

--- a/src/pages/channel/ArchivePage.jsx
+++ b/src/pages/channel/ArchivePage.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ArchiveButtonListContainer from '../../containers/archive/ArchiveButtonListContainer';
+import ArchiveContainer from '../../containers/archive/ArchiveContainer';
+import CommentsContainer from '../../containers/common/CommentsContainer';
+import FooterContainer from '../../containers/common/FooterContainer';
+import HeaderContainer from '../../containers/common/HeaderContainer';
+import ChannelNavContainer from './../../containers/channel/ChannelNavContainer';
+
+const ArchivePage = ({ match }) => {
+  const { channelId, archiveId } = match.params;
+  return (
+    <>
+      <HeaderContainer />
+      <ChannelNavContainer />
+      <ArchiveContainer channelId={parseInt(channelId, 10)} archiveId={parseInt(archiveId, 10)} />
+      <ArchiveButtonListContainer
+        channelId={parseInt(channelId, 10)}
+        archiveId={parseInt(archiveId, 10)}
+      />
+      <CommentsContainer channelId={parseInt(channelId, 10)} postId={parseInt(archiveId, 10)} />
+      <FooterContainer />
+    </>
+  );
+};
+
+export default ArchivePage;

--- a/src/routers/ChannelRouter.jsx
+++ b/src/routers/ChannelRouter.jsx
@@ -8,7 +8,8 @@ import EditChannelPage from '../pages/channel/EditChannelPage';
 import CheckJoinChannel from '../middlewares/CheckJoinChannel';
 import EditPostPage from '../pages/channel/EditPostPage';
 import ChannelChatListPage from '../pages/channel/ChannelChatListPage';
-import ChannelArchiveListPage from '../pages/channel/ChannelArchiveListPage';
+import ArchiveListPage from '../pages/channel/ArchiveListPage';
+import ArchivePage from '../pages/channel/ArchivePage';
 
 const ChannelRouter = () => {
   return (
@@ -32,12 +33,12 @@ const ChannelRouter = () => {
       <Route
         path="/channel/:channelId/archive"
         exact
-        render={(props) => <CheckJoinChannel {...props} Component={ChannelArchiveListPage} />}
+        render={(props) => <CheckJoinChannel {...props} Component={ArchiveListPage} />}
       />
       <Route
         path="/channel/:channelId/archive/:archiveId"
         exact
-        render={(props) => <CheckJoinChannel {...props} Component={ChannelArchiveListPage} />}
+        render={(props) => <CheckJoinChannel {...props} Component={ArchivePage} />}
       />
       <Route
         path="/channel/:channelId/chat"


### PR DESCRIPTION
# 개발사항
- 채널 모아보기 페이지 구현
- 모아보기 개별 게시글 뷰 구현
- 모아보기 글의 본문(content, md형식) 뷰 구현

## 세부사항
### 채널 모아보기 페이지 구현
- 아카이브에 이미지가 없는 경우 이미지 보여주는 공간을 없앰

### 모아보기 개별 게시글 뷰 구현
- 요청이 해결된 글인 경우 확인할 수 있는 `요청 확인` 딱지와 요청글 바로가기 버튼 표시
- 재능 공유 요청 글에 없는 태그 표시

### 모아보기 글의 본문(content, md형식) 뷰 구현
- 질문, 답변은 Toast UI 에디터의 Hook을 사용하여 렌더링

## 추가사항
- comments api 수정으로 인한 파라미터 전달 방식 수정
- 공감 기능 구현