### PR TITLE
채널 홈에서 재능 공유 요청 렌더링 오류 해결

### DIFF
--- a/src/containers/channel/ChannelHomeContainer.jsx
+++ b/src/containers/channel/ChannelHomeContainer.jsx
@@ -14,7 +14,9 @@ const ChannelHomeContainer = ({ channelId }) => {
 
   useEffect(() => {
     dispatch(getRoomList(channelId));
-    dispatch(getChannelPostList(channelId, qs.stringify({ type: 'All', page: 1, pageSize: 5 })));
+    dispatch(
+      getChannelPostList({ channelId, query: qs.stringify({ type: 'All', page: 1, pageSize: 5 }) }),
+    );
     dispatch(getChannelData(channelId));
   }, [dispatch, channelId]);
 


### PR DESCRIPTION
# 개발사항

-   채널 홈에서 재능 공유 요청 렌더링 오류 해결

## 세부사항

```js
export const getChannelPostList = async ({ channelId, query }) => {
```
API 에 query인자를 추가하게 되면서 객체형식의 인자를 받게 됐는데

```js
getChannelPostList(channelId, qs.stringify({ type: 'All', page: 1, pageSize: 5 })),
```
채널 홈에서는 객체형으로 인자를 주지 않아 생긴 에러입니다.

기존에 잠깐씩 되는 것처럼 보였던 것은, 채널 공유 요청 리스트 페이지에서 postList를 리덕스에 저장해둔 상태였기 때문입니다.

## 추가사항
#108 