### PR TITLE
채널 모아보기 데이터 연동

### DIFF
--- a/src/components/channel/ArchiveCard.jsx
+++ b/src/components/channel/ArchiveCard.jsx
@@ -1,16 +1,20 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { Box, Grid, Typography } from '@material-ui/core';
+import { useHistory } from 'react-router-dom';
+import { Box, Typography } from '@material-ui/core';
 import { getRandomColor } from '../../lib/util/random';
 
-const ArchiveCard = ({ post }) => {
+const ArchiveCard = ({ archive }) => {
+  const history = useHistory();
+
   return (
     <Box
       css={archiveCard}
       sx={{
-        backgroundColor: getRandomColor(post.title),
-        backgroundImage: `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.510208) 75.52%, rgba(0, 0, 0, 0.79) 100%), url(${post.imgUrl})`,
+        backgroundColor: getRandomColor(archive.title),
+        backgroundImage: `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.510208) 75.52%, rgba(0, 0, 0, 0.79) 100%), url(${archive.imgUrl})`,
       }}
+      onClick={() => history.push(`/channel/${archive.channelId}/archive/${archive.id}`)}
     >
       <Box
         sx={{
@@ -19,13 +23,8 @@ const ArchiveCard = ({ post }) => {
           padding: '12.5px',
         }}
       >
-        <Typography
-          className="archiveTitle"
-          gutterBottom
-          component="div"
-          sx={archiveTitle}
-        >
-          {post.title}
+        <Typography className="archiveTitle" gutterBottom component="div" sx={archiveTitle}>
+          {archive.title}
         </Typography>
         <Typography
           sx={{
@@ -35,7 +34,7 @@ const ArchiveCard = ({ post }) => {
             alignSelf: 'flex-end',
           }}
         >
-          {post.date}
+          {archive.date}
         </Typography>
       </Box>
     </Box>

--- a/src/components/channel/ArchiveCard.jsx
+++ b/src/components/channel/ArchiveCard.jsx
@@ -3,13 +3,14 @@ import { css } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 import { Box, Typography } from '@material-ui/core';
 import { getRandomColor } from '../../lib/util/random';
+import { getDateString } from '../../lib/util/dateFormat';
 
-const ArchiveCard = ({ archive }) => {
+const ArchiveCard = ({ archive, width }) => {
   const history = useHistory();
 
   return (
     <Box
-      css={archiveCard}
+      css={archiveCard(width)}
       sx={{
         backgroundColor: getRandomColor(archive.title),
         backgroundImage: `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.510208) 75.52%, rgba(0, 0, 0, 0.79) 100%), url(${archive.imgUrl})`,
@@ -34,15 +35,15 @@ const ArchiveCard = ({ archive }) => {
             alignSelf: 'flex-end',
           }}
         >
-          {archive.date}
+          {getDateString(archive.createdAt)}
         </Typography>
       </Box>
     </Box>
   );
 };
 
-const archiveCard = css`
-  width: 10.3125rem;
+const archiveCard = (width) => css`
+  width: ${width ? width : '10.3125rem'};
   height: 15rem;
   cursor: pointer;
   border-radius: 5px;

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -119,6 +119,7 @@ const channerHomeWrapper = css`
   padding: 1rem calc((100% - 71.25rem) / 2);
   background-color: #fafafc;
   display: flex;
+  padding-bottom: 6.25rem;
 `;
 
 const rightContent = css`

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -10,38 +10,7 @@ import { ReactComponent as PostIcon } from '../../lib/assets/postIcon.svg';
 import PostCard from './PostCard';
 import { useHistory } from 'react-router';
 
-const archived = [
-  {
-    title: '머핀이 잘 부풀지 않을때 어떻게 해야할까?',
-    date: '2021.09.07',
-    imgUrl:
-      'https://i2.wp.com/smittenkitchen.com/wp-content/uploads//2010/08/perfect-blueberry-muffins.jpg?fit=750%2C500&ssl=1',
-  },
-  {
-    title: '멋있게 춤추기 위해 알아야 하는 기본 동작',
-    date: '2021.08.14',
-    imgUrl: 'https://pbs.twimg.com/profile_images/625698094345117696/pjhb6Zgx_400x400.jpg',
-  },
-  {
-    title: '몸에 좋고 맛있는 샐러드 만드는 방법',
-    date: '2021.07.02',
-  },
-  {
-    title: '홈페이지를 만들 때 사용할 수 있는 여러 무료 이미지 알려드립니다!',
-    date: '2021.03.18',
-  },
-  {
-    title: '유연성을 기르기 위한 여러가지 동작',
-    date: '2021.01.04',
-  },
-  {
-    title: '사실적으로 눈 그리는 방법',
-    date: '2020.12.11',
-    imgUrl: 'https://t1.daumcdn.net/cfile/blog/9905734D5C01316F32',
-  },
-];
-
-const ChannerHome = ({ channel, postList, roomList }) => {
+const ChannerHome = ({ channel, postList, roomList, channelArchive }) => {
   const history = useHistory();
 
   return (
@@ -101,13 +70,19 @@ const ChannerHome = ({ channel, postList, roomList }) => {
             <Typography css={contentTitle}>모아보기</Typography>
             <Button onClick={() => history.push(`/channel/${channel.id}/archive`)}>더보기</Button>
           </Box>
-          <Grid container spacing={3}>
-            {archived.map((post, i) => (
-              <Grid item key={i}>
-                <ArchiveCard post={post} />
-              </Grid>
-            ))}
-          </Grid>
+          {channelArchive?.length > 0 ? (
+            <Grid container spacing={3}>
+              {channelArchive?.map((archive, i) => (
+                <Grid item key={i}>
+                  <ArchiveCard archive={archive} />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Typography css={[noContent, { height: '100px', lineHeight: '100px' }]}>
+              아직 등록된 글이 없습니다.
+            </Typography>
+          )}
         </Box>
       </Box>
     </Box>

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -71,10 +71,10 @@ const ChannerHome = ({ channel, postList, roomList, channelArchive }) => {
             <Button onClick={() => history.push(`/channel/${channel.id}/archive`)}>더보기</Button>
           </Box>
           {channelArchive?.length > 0 ? (
-            <Grid container spacing={3}>
+            <Grid container spacing="1.25rem">
               {channelArchive?.map((archive, i) => (
                 <Grid item key={i}>
-                  <ArchiveCard archive={archive} />
+                  <ArchiveCard archive={archive} width="10.625rem" />
                 </Grid>
               ))}
             </Grid>

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -54,7 +54,7 @@ const ChannerHome = ({ channel, postList, roomList }) => {
               재능 공유 요청 <PostIcon css={{ marginLeft: '.5625rem' }} />
             </Typography>
 
-            <Button onClick={() => history.push(`/channel/${channel.id}/postList`)}>더보기</Button>
+            <Button onClick={() => history.push(`/channel/${channel.id}/post`)}>더보기</Button>
           </Box>
           {postList?.length > 0 ? (
             <Box

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -99,7 +99,7 @@ const ChannerHome = ({ channel, postList, roomList }) => {
         <Box css={contentWrapper}>
           <Box css={contentTitleWrapper}>
             <Typography css={contentTitle}>모아보기</Typography>
-            <Button>더보기</Button>
+            <Button onClick={() => history.push(`/channel/${channel.id}/archive`)}>더보기</Button>
           </Box>
           <Grid container spacing={3}>
             {archived.map((post, i) => (

--- a/src/components/channel/ChannelProfile.jsx
+++ b/src/components/channel/ChannelProfile.jsx
@@ -12,11 +12,12 @@ import Button from '../common/Button';
 import { useEffect, useState } from 'react';
 import ProfileModal from '../common/ProfileModal';
 import ModalUserCard from '../common/ModalUserCard';
+import ArchiveCard from './ArchiveCard';
 
 const ChannelProfile = ({
   user,
   channel,
-  collection,
+  channelArchive,
   onEnterChannel,
   onExitChannel,
   isParticipant,
@@ -180,25 +181,19 @@ const ChannelProfile = ({
           <Typography css={sectionTitle}>
             모아보기 <Button css={moreButton}>더보기</Button>
           </Typography>
-          <Grid container spacing={3}>
-            {collection.map((collection) => (
-              <Grid item key={collection.id}>
-                <Paper
-                  css={[
-                    channelCollection,
-                    css`
-                      background-image: url(${collection.image.src});
-                    `,
-                  ]}
-                >
-                  <Box css={channelCollectionLayer}>
-                    <Typography css={collectionTitle}>{collection.title}</Typography>
-                    <Typography css={collectionCreatedAt}>{collection.createdAt}</Typography>
-                  </Box>
-                </Paper>
-              </Grid>
-            ))}
-          </Grid>
+          {channelArchive?.length > 0 ? (
+            <Grid container spacing={3} columns={5}>
+              {channelArchive?.map((archive) => (
+                <Grid item key={archive.id}>
+                  <ArchiveCard archive={archive} width="10.625rem" />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Typography css={[noContent, { height: '100px', lineHeight: '100px' }]}>
+              아직 등록된 글이 없습니다.
+            </Typography>
+          )}
         </Box>
       </Box>
     </>
@@ -423,45 +418,11 @@ const moreButton = css`
   font-size: 1rem;
 `;
 
-const channelCollection = css`
-  width: 10.625rem;
-  height: 15rem;
-  background: #87eec3;
-  background-size: cover;
-  background-repeat: no-repeat;
-  box-shadow: 0px 2px 5px 3px rgba(0, 0, 0, 0.3);
-  border-radius: 4.53975px;
-`;
-
-const channelCollectionLayer = css`
-  height: 100%;
-  background: linear-gradient(
-    180deg,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.510208) 75.52%,
-    rgba(0, 0, 0, 0.79) 100%
-  );
-  border-radius: 4.53975px;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: 0.709375rem 1.3125rem;
-`;
-
-const collectionTitle = css`
-  font-family: 'Barlow', 'Noto Sans KR';
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: ${palette.white};
-`;
-
-const collectionCreatedAt = css`
-  font-family: 'Barlow', 'Noto Sans KR';
-  font-size: 0.45rem;
-  font-weight: 500;
-  text-align: right;
-  color: ${palette.white};
+const noContent = css`
+  text-align: center;
+  width: 100%;
+  font-family: 'Noto Sans KR';
+  color: #5f5f5f;
 `;
 
 export default ChannelProfile;

--- a/src/components/channel/ChannelProfile.jsx
+++ b/src/components/channel/ChannelProfile.jsx
@@ -10,6 +10,7 @@ import palette from '../../lib/styles/palette';
 import CheckIcon from '@material-ui/icons/Check';
 import Button from '../common/Button';
 import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import ProfileModal from '../common/ProfileModal';
 import ModalUserCard from '../common/ModalUserCard';
 import ArchiveCard from './ArchiveCard';
@@ -30,6 +31,7 @@ const ChannelProfile = ({
   onProfileFollow,
   onProfileUnfollow,
 }) => {
+  const history = useHistory();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [tabs, setTabs] = useState([{ key: 'members', name: '재능 공유 멤버', data: <></> }]);
   const [currentTab, setCurrentTab] = useState('members');
@@ -179,7 +181,10 @@ const ChannelProfile = ({
         </Box>
         <Box>
           <Typography css={sectionTitle}>
-            모아보기 <Button css={moreButton}>더보기</Button>
+            모아보기{' '}
+            <Button css={moreButton} onClick={() => history.push(`/channel/${channel.id}/archive`)}>
+              더보기
+            </Button>
           </Typography>
           {channelArchive?.length > 0 ? (
             <Grid container spacing={3} columns={5}>

--- a/src/containers/channel/ChannelHomeContainer.jsx
+++ b/src/containers/channel/ChannelHomeContainer.jsx
@@ -5,10 +5,12 @@ import { getChannelData } from '../../modules/channel';
 import { getRoomList } from '../../modules/room';
 import { getChannelPostList } from '../../modules/post';
 import qs from 'qs';
+import { getChannelArchive } from '../../modules/archive';
 
 const ChannelHomeContainer = ({ channelId }) => {
   const { channel } = useSelector((state) => state.channel);
   const { postList } = useSelector((state) => state.post);
+  const { channelArchive } = useSelector((state) => state.archive);
   const { roomList } = useSelector((state) => state.room);
   const dispatch = useDispatch();
 
@@ -17,12 +19,20 @@ const ChannelHomeContainer = ({ channelId }) => {
     dispatch(
       getChannelPostList({ channelId, query: qs.stringify({ type: 'All', page: 1, pageSize: 5 }) }),
     );
+    dispatch(getChannelArchive(channelId));
     dispatch(getChannelData(channelId));
   }, [dispatch, channelId]);
 
   if (!channel) return '로딩중';
 
-  return <ChannelHome channel={channel} postList={postList} roomList={roomList} />;
+  return (
+    <ChannelHome
+      channel={channel}
+      postList={postList}
+      roomList={roomList}
+      channelArchive={channelArchive}
+    />
+  );
 };
 
 export default ChannelHomeContainer;

--- a/src/containers/channel/ChannelProfileContainer.jsx
+++ b/src/containers/channel/ChannelProfileContainer.jsx
@@ -13,46 +13,11 @@ import {
 import { profileFollow, profileUnfollow } from '../../modules/profile';
 import { follow, unfollow } from '../../modules/user';
 import { setChannel } from '../../modules/write';
+import { getChannelArchive } from '../../modules/archive';
 
 const ChannelProfileContainer = ({ channelId }) => {
-  const [collection] = useState([
-    {
-      id: 1,
-      title: '머핀이 잘 부풀지 않을 때 어떻게 해야할까?',
-      createdAt: '2021.08.11',
-      image: {
-        src: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQC2heqt7TxZUbE931X-x7ALY2wwxp40zxJBQ&usqp=CAU',
-      },
-    },
-    {
-      id: 3,
-      title: '머핀이 잘 부풀지 않을 때 어떻게 해야할까?',
-      createdAt: '2021.08.11',
-      image: {
-        src: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTv-G51ZeeG3VS3dszzCGnGuIz5JdvqLfXDuQ&usqp=CAU',
-      },
-    },
-    {
-      id: 4,
-      title: '머핀이 잘 부풀지 않을 때 어떻게 해야할까?',
-      createdAt: '2021.08.11',
-      image: { src: '' },
-    },
-    {
-      id: 5,
-      title: '머핀이 잘 부풀지 않을 때 어떻게 해야할까?',
-      createdAt: '2021.08.11',
-      image: { src: '' },
-    },
-    {
-      id: 8,
-      title: '머핀이 잘 부풀지 않을 때 어떻게 해야할까?',
-      createdAt: '2021.08.11',
-      image: { src: '' },
-    },
-  ]);
-
   const { channel } = useSelector((state) => state.channel);
+  const { channelArchive } = useSelector((state) => state.archive);
   const { user } = useSelector((state) => state.user);
   const [isParticipant, setIsParticipant] = useState(false);
   const [isLiked, setIsLiked] = useState(false);
@@ -100,6 +65,7 @@ const ChannelProfileContainer = ({ channelId }) => {
   };
 
   useEffect(() => {
+    dispatch(getChannelArchive(channelId));
     dispatch(getChannelData(channelId));
     return () => {
       dispatch(initChannel());
@@ -124,7 +90,7 @@ const ChannelProfileContainer = ({ channelId }) => {
     <ChannelProfile
       user={user}
       channel={channel}
-      collection={collection}
+      channelArchive={channelArchive}
       onEnterChannel={onEnterChannel}
       onExitChannel={onExitChannel}
       isParticipant={isParticipant}


### PR DESCRIPTION
# 개발사항

-   채널 홈 페이지 모아보기 컴포넌트 연동
-   채널 프로필 페이지 모아보기 컴포넌트 연동
-  채널 홈 페이지 모아보기 더보기 버튼 기능 추가
-  채널 프로필 페이지 모아보기 더보기 버튼 기능 추가

## 세부사항
### 채널 홈 페이지 모아보기 컴포넌트 연동
-   채널 ID로 아카이브 조회 API 사용
- Private, Public 아카이브 조회는 API 내에서 구현

### 채널 프로필 페이지 모아보기 컴포넌트 연동
-   채널 ID로 아카이브 조회 API 사용
- Private, Public 아카이브 조회는 API 내에서 구현

### 모아보기 더보기 버튼 기능 추가
- 채널 모아보기 페이지로 이동

## 추가사항
- 채널 홈 재능 공유 요청 더보기 버튼 이동 URL 수정
- 채널 홈 아래 여백 추가
- ArchiveCard 컴포넌트에 width 프로퍼티 추가