### PR TITLE
채널 홈 채팅방 데이터 연동

### DIFF
--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -51,13 +51,16 @@ const ChannerHome = ({ channel, postList, roomList, channelArchive }) => {
             </Box>
             <Button>더보기</Button>
           </Box>
-          {roomList?.length > 0 ? (
-            <Grid container spacing={3}>
-              {roomList?.openRoom.map((chatInfo, i) => (
-                <Grid item key={i}>
-                  <ChannelHomeChatCard chatInfo={chatInfo} />
-                </Grid>
-              ))}
+          {roomList?.openRoom.length > 0 ? (
+            <Grid container columnGap="1.25rem" rowGap="1.5rem">
+              {roomList.openRoom
+                .slice(-6)
+                .reverse()
+                .map((room) => (
+                  <Grid item key={room.id}>
+                    <ChannelHomeChatCard room={room} />
+                  </Grid>
+                ))}
             </Grid>
           ) : (
             <Typography css={[noContent, { height: '100px', lineHeight: '100px' }]}>

--- a/src/components/channel/ChannelHome.jsx
+++ b/src/components/channel/ChannelHome.jsx
@@ -49,7 +49,7 @@ const ChannerHome = ({ channel, postList, roomList, channelArchive }) => {
               <Typography css={contentTitle}>오픈된 채팅방</Typography>
               <ChatIcon css={{ marginLeft: '.4rem' }} />
             </Box>
-            <Button>더보기</Button>
+            <Button onClick={() => history.push(`/channel/${channel.id}/room`)}>더보기</Button>
           </Box>
           {roomList?.openRoom.length > 0 ? (
             <Grid container columnGap="1.25rem" rowGap="1.5rem">

--- a/src/components/channel/ChannelHomeChatCard.jsx
+++ b/src/components/channel/ChannelHomeChatCard.jsx
@@ -6,43 +6,42 @@ import { ReactComponent as Owner } from '../../lib/assets/owner.svg';
 import { ReactComponent as Participants } from '../../lib/assets/participants.svg';
 import { ReactComponent as Time } from '../../lib/assets/time.svg';
 
-const ChannelHomeChatCard = ({ chatInfo }) => {
+const ChannelHomeChatCard = ({ room }) => {
   const handleMoveChat = (roomId) => {
     window.open(`/room/${roomId}`, '_blank', 'width=600, height=900, toolbars=no, scrollbars=yes');
     return false;
   };
 
   return (
-    <Box
-      css={CharCardWrapper}
-      onClick={() => {
-        handleMoveChat(chatInfo.id);
-      }}
-    >
-      <Typography css={title}>{chatInfo.name}</Typography>
-      <Typography css={description}>
-        <Participants className="icon" />
-        {chatInfo.roomParticipant.length}
-      </Typography>
-      <Typography css={description}>
-        <Owner className="icon" />
-        {chatInfo.roomOwner.nickname}
-      </Typography>
-      <Typography css={description}>
-        <Time className="icon" />
-        {new Date(chatInfo.createdAt).toLocaleString()}
-      </Typography>
+    <Box css={wrapper} onClick={() => handleMoveChat(room.id)}>
+      <Box>
+        <Typography css={title}>{room.name}</Typography>
+      </Box>
+      <Box css={descriptions}>
+        <Typography css={description}>
+          <Participants className="icon" />
+          {room.roomParticipant.length}
+        </Typography>
+        <Typography css={description}>
+          <Owner className="icon" />
+          {room.roomOwner.nickname}
+        </Typography>
+        <Typography css={description}>
+          <Time className="icon" />
+          {new Date(room.createdAt).toLocaleString()}
+        </Typography>
+      </Box>
     </Box>
   );
 };
 
-const CharCardWrapper = css`
-  width: 10.3125rem;
+const wrapper = css`
+  width: 10.625rem;
   height: 8.125rem;
-  padding: 0.9375rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   text-align: center;
   background: white;
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.7);
@@ -57,39 +56,23 @@ const title = css`
   font-family: 'Barlow', 'Noto Sans KR';
   font-size: 0.75rem;
   font-weight: 600;
-  position: relative;
-  top: -0.5rem;
-  flex: 1;
+`;
+
+const descriptions = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: 0.4688rem;
 `;
 
 const description = css`
-  font-family: 'Barlow', 'Noto Sans KR';
-  font-size: 0.625rem;
-  font-weight: 500;
-  color: #7b7b7b;
-  .icon {
-    margin-right: 0.1625rem;
-  }
-`;
-
-const bottomContent = css`
   display: flex;
   align-items: center;
-  background: #f0f0f0;
-  padding: 0.9375rem;
-  border-radius: 0 0 5px 5px;
-`;
-
-const bottomIcon = css`
-  width: 1.875rem;
-  height: 1.875rem;
-`;
-
-const bottomTitle = css`
+  column-gap: 0.625rem;
   font-family: 'Barlow', 'Noto Sans KR';
   font-size: 0.625rem;
-  font-weight: 400;
-  margin-left: 0.5rem;
+  color: #7b7b7b;
 `;
 
 export default ChannelHomeChatCard;


### PR DESCRIPTION
# 개발사항

-   채널 홈 채팅방 데이터 연동
-   디자인 수정

## 세부사항

### 채널 홈 채팅방 데이터 연동

-   room 모듈 roomList.openRoom 배열의 마지막 6개를 reverse하여 createdAt 내림차순으로 표시

### 디자인 수정
-   `ChannelHomeChatCard` 세부 디자인 수정

## 추가사항
- 채널 홈 채팅방 더보기 버튼 클릭 시, 채널 재능 공유 채팅 탭으로 이동 구현