### PR TITLE
Fix: 채널 프로필 모아보기 API 연동 query 추가 (#156)

### DIFF
--- a/src/containers/channel/ChannelProfileContainer.jsx
+++ b/src/containers/channel/ChannelProfileContainer.jsx
@@ -65,7 +65,7 @@ const ChannelProfileContainer = ({ channelId }) => {
   };
 
   useEffect(() => {
-    dispatch(getChannelArchive(channelId));
+    dispatch(getChannelArchive({ channelId, query: 'page=1&pageSize=5' }));
     dispatch(getChannelData(channelId));
     return () => {
       dispatch(initChannel());


### PR DESCRIPTION
# 개발사항

-   채널 프로필 모아보기 데이터 연동 로직 수정

## 세부사항

### 채널 프로필 모아보기 데이터 연동 로직 수정

-  5개의 모아보기 글을 불러오도록 query 파라미터 추가
