### PR TITLE
refactor: message 이벤트 헨들러 클린업  (#176)

### DIFF
--- a/src/containers/channel/ChannelTalkContainer.jsx
+++ b/src/containers/channel/ChannelTalkContainer.jsx
@@ -32,6 +32,9 @@ const ChannelTalkContainer = ({ channel }) => {
         dispatch(concatChannelMessages(message));
       }
     });
+    return () => {
+      socket.off('message');
+    };
   }, []);
 
   const handleSendMessage = async () => {

--- a/src/containers/room/RoomContainer.jsx
+++ b/src/containers/room/RoomContainer.jsx
@@ -49,6 +49,10 @@ const RoomContainer = ({ roomId }) => {
     socket.on('RoomInfo', (participantInfo) => {
       setParticipants(participantInfo);
     });
+    return () => {
+      socket.off('message');
+      socket.off('RoomInfo');
+    };
   }, []);
 
   const handleSendMessage = async () => {


### PR DESCRIPTION
# 개발사항

- 채널 홈에서 한번 등록된 이벤트 핸들러가 다른 페이지 이동시 사라지지 않고 홈을 다시 방문하면 이벤트 핸들러가 중복 등록되어 소켓으로 받은 메세지가 중복 랜더링되는 버그가 있었음
- 이벤트 핸들러를 클린업함수에서 제거해줘서 해결

## 추가사항