### PR TITLE
Feat: 헤더 프로필 사진 적용

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -14,6 +14,7 @@ import {
   Typography,
   ClickAwayListener,
   useMediaQuery,
+  Avatar,
 } from '@material-ui/core';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { memo, useEffect, useState } from 'react';
@@ -130,7 +131,11 @@ const Header = ({ user, onLogout }) => {
           >
             <Box>
               <IconButton css={iconButton} onClick={handleMenu}>
-                <UserProfile />
+                {user.profile.profileImage ? (
+                  <Avatar src={user.profile.profileImage} />
+                ) : (
+                  <UserProfile />
+                )}
               </IconButton>
               <Popper
                 open={!!menuAnchor}

--- a/src/containers/profile/setting/ProfileSettingContainer.jsx
+++ b/src/containers/profile/setting/ProfileSettingContainer.jsx
@@ -23,8 +23,14 @@ const ProfileSettingContainer = () => {
     dispatch(checkPassword({ password }));
   };
 
-  const onUpdateProfile = ({ nickname, department, introduce, wellTalent, interestTalent }) => {
-    dispatch(
+  const onUpdateProfile = async ({
+    nickname,
+    department,
+    introduce,
+    wellTalent,
+    interestTalent,
+  }) => {
+    await dispatch(
       updateProfile({
         userId: user.id,
         nickname,
@@ -35,6 +41,7 @@ const ProfileSettingContainer = () => {
         src: profileImage,
       }),
     );
+    dispatch(check());
   };
 
   const onCheckNickname = ({ nickname }) => {


### PR DESCRIPTION
# 개발사항

-   헤더 프로필 사진 적용

## 세부사항

### 헤더 프로필 사진 적용
-   로그인 상태일 때 유저에게 프로필 사진이 없으면 기본 이미지를 보여주고, 있다면 프로필 사진을 보여준다.
- 프로필 사진을 수정하면 바로 헤더에 반영한다.

