### PR TITLE
Refactor: 채널 참여자가 관리자만 있는 경우 모달창 디자인 수정

### DIFF
--- a/src/components/channel/ChannelProfile.jsx
+++ b/src/components/channel/ChannelProfile.jsx
@@ -59,7 +59,7 @@ const ChannelProfile = ({
     if (channel?.participants) {
       newTabs.find((tab) => tab.key === 'members').data =
         channel.participants.length === 0 ? (
-          <Grid container height="67vh" justifyContent="center" alignItems="center">
+          <Grid>
             <ModalUserCard
               loggedInUser={user}
               profileUserId={channel.admin.id}


### PR DESCRIPTION
# 개발사항
-   채널 참여자가 관리자만 있는 경우 모달창 디자인 수정

## 세부사항
### 채널 참여자가 관리자만 있는 경우 모달창 디자인 수정
-   관리자의 `ModalUserCard`가 중앙으로 배치되는 문제 해결

