### PR TITLE
fix: 잡담방 두번 렌더링 해결  (#208)

### DIFF
--- a/src/containers/channel/ChannelProfileContainer.jsx
+++ b/src/containers/channel/ChannelProfileContainer.jsx
@@ -83,9 +83,6 @@ const ChannelProfileContainer = ({ channelId }) => {
   useEffect(() => {
     dispatch(getChannelArchive({ channelId, query: 'page=1&pageSize=5' }));
     dispatch(getChannelData(channelId));
-    return () => {
-      dispatch(initChannel());
-    };
   }, [dispatch, channelId]);
 
   useEffect(() => {


### PR DESCRIPTION
# 개발사항

-   잡담방 두번 렌더링 해결

## 세부사항
채널 데이터를 다시 받아오는 과정에서 소켓 이벤트가 두번 등록된듯함

## 추가사항